### PR TITLE
No armv7

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   IMAGE_NAME: gnzsnz/torproxy
-  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:
@@ -30,11 +29,6 @@ jobs:
         while IFS= read -r line; do 
           echo $line >> $GITHUB_ENV ; 
         done < .env
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: ${{ env.PLATFORMS }}
         
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -48,7 +42,6 @@ jobs:
         build-args: |
           BASE_VERSION=${{ env.BASE_VERSION }}
           IMAGE_VERSION=${{ env.IMAGE_VERSION }}
-        platforms: ${{ env.PLATFORMS }}
         tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}-${{ matrix.image_os }}
 
     - name: Run container

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   IMAGE_NAME: gnzsnz/torproxy
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:
@@ -33,7 +34,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ env.PLATFORMS }}
         
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -47,6 +48,7 @@ jobs:
         build-args: |
           BASE_VERSION=${{ env.BASE_VERSION }}
           IMAGE_VERSION=${{ env.IMAGE_VERSION }}
+        platforms: ${{ env.PLATFORMS }}
         tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}-${{ matrix.image_os }}
 
     - name: Run container

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
 env:
   IMAGE_NAME: gnzsnz/torproxy
   LATEST_TAG: jammy
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   publish:
@@ -32,7 +33,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -69,6 +70,6 @@ jobs:
           build-args: |
             BASE_VERSION=${{ env.BASE_VERSION }}
             IMAGE_VERSION=${{ env.IMAGE_VERSION }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ env.PLATFORMS }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- remove multiarch from build and test. buildx does not support load with multiarch.
- multiarch will be done only on publish
- remove arm/v7 from build. tor project does not provide arm/v7 binaries

